### PR TITLE
Deploy 🎉 

### DIFF
--- a/packages/react-kit/src/core/FormControl/FormControlLabel.tsx
+++ b/packages/react-kit/src/core/FormControl/FormControlLabel.tsx
@@ -18,9 +18,9 @@ const FormControlLabel = ({ children, visuallyHidden, ...props }: PropsWithChild
     <VisuallyHidden as={'label'} htmlFor={id} sx={{ width: 'fit-content' }} isVisible={!visuallyHidden}>
       <LabelWrapper {...props} disabled={disabled}>
         {children}
-        {required ? (
+        {typeof required === 'boolean' && required === false ? (
           <View as={'span'} aria-hidden="true">
-            {' *'}
+            {' (선택)'}
           </View>
         ) : null}
       </LabelWrapper>
@@ -59,6 +59,12 @@ const LabelWrapper = styled(View)<SxProp & FormControlContextValue>`
   color: ${({ theme }) => theme.colors['text/neutral/subtle']};
 
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+
+  span {
+    font-size: inherit;
+    font-weight: inherit;
+    color: ${({ theme }) => theme.colors['text/neutral/subtlest']};
+  }
 
   ${sx};
 `;

--- a/packages/react-kit/src/core/FormControl/index.tsx
+++ b/packages/react-kit/src/core/FormControl/index.tsx
@@ -52,7 +52,7 @@ const FormControl = (
     children: propChildren,
     id,
     disabled,
-    required,
+    required = true,
     additionalInputComponentCandidates = [],
     sx,
     ...props


### PR DESCRIPTION
FormControl.required 값의 여부에 따라 표현하는 방식을 변경합니다.

기존: required = true 일 때, `Label *` 형식으로 표현. required = false 일 때, **아무 표시 하지 않음**.
신규: required = true 일 때, **아무 표시 하지 않음**. required = false 일 때, `Label (선택)` 형식으로 표현.