### PR TITLE
Deploy ♿️

### DIFF
--- a/packages/react-kit/src/core/Breadcrumbs/index.tsx
+++ b/packages/react-kit/src/core/Breadcrumbs/index.tsx
@@ -26,25 +26,33 @@ const Breadcrumbs = ({ children, maxItemCount = 5, ...props }: PropsWithChildren
       ];
 
   return (
-    <BaseBreadcrumbs {...props}>
-      {Children.map(breadcrumbsItems, (child) => (
-        <BreadcrumbsItemWrapper role={'listitem'}>{child}</BreadcrumbsItemWrapper>
-      ))}
+    <BaseBreadcrumbs aria-label={'Breadcrumb'} {...props}>
+      <BreadcrumbsList>
+        {Children.map(breadcrumbsItems, (child) => (
+          <BreadcrumbsItemWrapper>{child}</BreadcrumbsItemWrapper>
+        ))}
+      </BreadcrumbsList>
     </BaseBreadcrumbs>
   );
 };
 
-const BaseBreadcrumbs = styled.nav`
+const BaseBreadcrumbs = styled.nav``;
+
+const BreadcrumbsList = styled.ol`
   display: flex;
   align-items: center;
   justify-content: flex-start;
   flex-wrap: wrap;
 
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
   column-gap: ${({ theme }) => forcePixelValue(theme.space[2])};
   row-gap: ${({ theme }) => forcePixelValue(theme.space[1])};
 `;
 
-const BreadcrumbsItemWrapper = styled.span`
+const BreadcrumbsItemWrapper = styled.li`
   display: inline-flex;
 
   &::after {

--- a/packages/react-kit/src/core/Pagination/index.tsx
+++ b/packages/react-kit/src/core/Pagination/index.tsx
@@ -167,6 +167,10 @@ type PaginationPageProps = { selected?: boolean };
 const PaginationPage = styled(UnstyledButton)<PaginationPageProps>`
   transition: background-color 100ms;
 
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
   height: ${forcePixelValue(32)};
   min-width: ${forcePixelValue(32)};
 


### PR DESCRIPTION
## 변경사항
- react-kit Breadcrumbs를 시맨틱 `<nav><ol><li>` 마크업으로 전환 (Lighthouse `aria-required-parent` 위반 해소)
- react-kit Pagination.Page에 명시적 `inline-flex` 부여하여 `as='span'`/Link 래핑 시에도 32px sizing 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)