### PR TITLE
Deploy 📊

### DIFF
--- a/packages/react-kit/src/core/Datagrid/DatagridBody.tsx
+++ b/packages/react-kit/src/core/Datagrid/DatagridBody.tsx
@@ -1,12 +1,14 @@
 import { forcePixelValue } from '@teamturing/utils';
-import { PropsWithChildren } from 'react';
+import { AriaAttributes, HTMLAttributes, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { SxProp, sx } from '../../utils/styled-system';
 
-type Props = {} & SxProp;
+type Props = {} & SxProp & Pick<HTMLAttributes<HTMLDivElement>, 'id' | 'role'> & AriaAttributes;
 
-const DatagridBody = ({ ...props }: PropsWithChildren<Props>) => <BaseDatagridBody {...props} />;
+const DatagridBody = ({ role, ...props }: PropsWithChildren<Props>) => (
+  <BaseDatagridBody role={role ?? 'rowgroup'} {...props} />
+);
 
 const BaseDatagridBody = styled.div<SxProp>`
   width: inherit;

--- a/packages/react-kit/src/core/Datagrid/DatagridCell.tsx
+++ b/packages/react-kit/src/core/Datagrid/DatagridCell.tsx
@@ -1,11 +1,20 @@
-import { PropsWithChildren } from 'react';
+import { AriaAttributes, HTMLAttributes, PropsWithChildren } from 'react';
 
 import Grid, { GridUnitProps } from '../Grid';
 
-type Props = {} & Pick<GridUnitProps, 'size' | 'sx'>;
+type Props = {
+  /**
+   * 셀을 열 헤더(`columnheader`)로 표시합니다. 기본값(`false`)은 데이터 셀(`cell`)입니다.
+   */
+  columnHeader?: boolean;
+} & Pick<GridUnitProps, 'size' | 'sx'> &
+  Pick<HTMLAttributes<HTMLDivElement>, 'id' | 'role' | 'tabIndex'> &
+  AriaAttributes;
 
-const DatagridCell = ({ children, ...props }: PropsWithChildren<Props>) => (
-  <BaseDatagridCell {...props}>{children}</BaseDatagridCell>
+const DatagridCell = ({ children, columnHeader = false, role, ...props }: PropsWithChildren<Props>) => (
+  <BaseDatagridCell role={role ?? (columnHeader ? 'columnheader' : 'cell')} {...props}>
+    {children}
+  </BaseDatagridCell>
 );
 
 const BaseDatagridCell = Grid.Unit;

--- a/packages/react-kit/src/core/Datagrid/DatagridHeader.tsx
+++ b/packages/react-kit/src/core/Datagrid/DatagridHeader.tsx
@@ -1,5 +1,5 @@
 import { forcePixelValue } from '@teamturing/utils';
-import { ElementType, HTMLAttributes, ReactElement, ReactNode } from 'react';
+import { AriaAttributes, ElementType, HTMLAttributes, ReactElement, ReactNode } from 'react';
 import { isValidElementType } from 'react-is';
 import styled from 'styled-components';
 
@@ -9,10 +9,13 @@ import View from '../View';
 type Props = {
   leadingVisual?: ElementType | ReactNode;
   trailingAction?: ReactElement<HTMLAttributes<HTMLElement>>;
-} & SxProp;
+} & SxProp &
+  Pick<HTMLAttributes<HTMLDivElement>, 'id'> &
+  AriaAttributes;
 
 const DatagridHeader = ({ leadingVisual: LeadingVisual, trailingAction, ...props }: Props) => (
   <DataGridHeaderWrapper {...props}>
+    {/* leadingVisual은 문자열이면 제목 텍스트로 렌더되어 표의 접근 가능한 이름으로 사용되므로 숨기지 않는다. */}
     <View sx={{ fontSize: 'xs', fontWeight: 'medium', lineHeight: 2, color: 'text/neutral/subtle' }}>
       {typeof LeadingVisual !== 'string' && isValidElementType(LeadingVisual) ? (
         <LeadingVisual />

--- a/packages/react-kit/src/core/Datagrid/DatagridRow.tsx
+++ b/packages/react-kit/src/core/Datagrid/DatagridRow.tsx
@@ -1,9 +1,24 @@
-import { PropsWithChildren } from 'react';
+import {
+  AriaAttributes,
+  Children,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+  cloneElement,
+  isValidElement,
+} from 'react';
 
 import Grid, { GridProps } from '../Grid';
 import Space, { SpaceProps } from '../Space';
 
-type Props = {} & Pick<GridProps, 'gapX' | 'alignItems' | 'justifyContent'> &
+import { DatagridCellProps } from './DatagridCell';
+
+type Props = {
+  /**
+   * 행을 열 제목 행으로 표시합니다. `true`이면 하위 `Datagrid.Cell`들이 열 헤더(`columnheader`)로 처리됩니다.
+   */
+  columnHeader?: boolean;
+} & Pick<GridProps, 'gapX' | 'alignItems' | 'justifyContent'> &
   Pick<
     SpaceProps,
     | 'p'
@@ -21,12 +36,38 @@ type Props = {} & Pick<GridProps, 'gapX' | 'alignItems' | 'justifyContent'> &
     | 'paddingBottom'
     | 'paddingLeft'
     | 'sx'
-  >;
+  > &
+  Pick<HTMLAttributes<HTMLDivElement>, 'id' | 'role' | 'tabIndex'> &
+  AriaAttributes;
 
-const DatagridRow = ({ gapX = 2, alignItems, justifyContent, children, ...props }: PropsWithChildren<Props>) => (
-  <DatagridRowWrapper {...props}>
-    <BaseDatagridRow wrap={false} gapX={gapX} alignItems={alignItems} justifyContent={justifyContent}>
-      {children}
+const DatagridRow = ({
+  gapX = 2,
+  alignItems,
+  justifyContent,
+  columnHeader = false,
+  role,
+  children,
+  ...props
+}: PropsWithChildren<Props>) => (
+  // 외부 wrapper가 `rowgroup`의 직접 자식이 되도록 여기에 role="row"를 부여하고,
+  // 셀을 직접 감싸는 내부 Grid는 presentation 처리하여 row가 cell을 직접 소유하도록 한다.
+  <DatagridRowWrapper role={role ?? 'row'} {...props}>
+    <BaseDatagridRow
+      role={'presentation'}
+      wrap={false}
+      gapX={gapX}
+      alignItems={alignItems}
+      justifyContent={justifyContent}
+    >
+      {columnHeader
+        ? Children.map(children, (child) =>
+            isValidElement(child)
+              ? cloneElement(child as ReactElement<DatagridCellProps>, {
+                  columnHeader: (child.props as DatagridCellProps).columnHeader ?? true,
+                })
+              : child,
+          )
+        : children}
     </BaseDatagridRow>
   </DatagridRowWrapper>
 );

--- a/packages/react-kit/src/core/Datagrid/DatagridRowList.tsx
+++ b/packages/react-kit/src/core/Datagrid/DatagridRowList.tsx
@@ -1,0 +1,47 @@
+import { isNullable } from '@teamturing/utils';
+import { ReactNode } from 'react';
+
+import ItemList, { ItemListProps } from '../ItemList';
+
+import DatagridCell, { DatagridCellProps } from './DatagridCell';
+import DatagridRow, { DatagridRowProps } from './DatagridRow';
+
+type Props<T extends { id: string }> = {
+  rows: readonly T[];
+  columns: readonly {
+    field: string;
+    size: DatagridCellProps['size'];
+    renderValue: (row: T, index: number) => ReactNode;
+  }[];
+  rowProps?: DatagridRowProps;
+  columnsTransformer?: (columns: Props<T>['columns']) => typeof columns;
+} & Pick<ItemListProps<T>, 'renderItemWrapper' | 'emptyState'>;
+
+const DatagridRowList = <T extends { id: string }>({
+  rows,
+  columns,
+  rowProps = { alignItems: 'center' },
+  renderItemWrapper,
+  emptyState,
+  columnsTransformer = (columns) => columns,
+}: Props<T>) => (
+  <ItemList
+    items={rows}
+    renderItem={(row, i) => (
+      <DatagridRow key={row.id} {...rowProps}>
+        {columnsTransformer(columns)
+          .filter((column) => !isNullable(column))
+          .map(({ field, renderValue, size }) => (
+            <DatagridCell key={field} size={size}>
+              {renderValue(row, i)}
+            </DatagridCell>
+          ))}
+      </DatagridRow>
+    )}
+    renderItemWrapper={renderItemWrapper}
+    emptyState={emptyState}
+  />
+);
+
+export default DatagridRowList;
+export type { Props as DatagridRowListProps };

--- a/packages/react-kit/src/core/Datagrid/index.tsx
+++ b/packages/react-kit/src/core/Datagrid/index.tsx
@@ -1,5 +1,5 @@
 import { forcePixelValue } from '@teamturing/utils';
-import { HTMLAttributes, PropsWithChildren } from 'react';
+import { HTMLAttributes, PropsWithChildren, ReactNode, cloneElement, isValidElement, useId } from 'react';
 import styled from 'styled-components';
 
 import useRelocation from '../../hook/useRelocation';
@@ -13,7 +13,14 @@ import DatagridSubheader from './DatagridSubheader';
 
 type Props = {} & HTMLAttributes<HTMLDivElement> & SxProp;
 
-const Datagrid = ({ children, sx, ...props }: PropsWithChildren<Props>) => {
+const Datagrid = ({
+  children,
+  sx,
+  role = 'table',
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  ...props
+}: PropsWithChildren<Props>) => {
   const [relocatableComponentsObject, restConmponents] = useRelocation({
     children,
     config: {
@@ -22,11 +29,24 @@ const Datagrid = ({ children, sx, ...props }: PropsWithChildren<Props>) => {
     },
   });
 
+  // Header가 있고 별도 라벨이 지정되지 않은 경우, Header를 표의 접근 가능한 이름으로 연결한다.
+  const generatedHeaderId = useId();
+  const { header: rawHeader, subHeader } = relocatableComponentsObject;
+  let headerNode: ReactNode = rawHeader;
+  let resolvedLabelledby = ariaLabelledby;
+  if (!ariaLabel && !ariaLabelledby && isValidElement(rawHeader)) {
+    const headerId = rawHeader.props.id ?? generatedHeaderId;
+    headerNode = cloneElement(rawHeader, { id: headerId });
+    resolvedLabelledby = headerId;
+  }
+
   return (
     <DatagridWrapper sx={sx}>
-      {relocatableComponentsObject.header}
-      {relocatableComponentsObject.subHeader}
-      <BaseDatagrid {...props}>{restConmponents}</BaseDatagrid>
+      {headerNode}
+      {subHeader}
+      <BaseDatagrid role={role} aria-label={ariaLabel} aria-labelledby={resolvedLabelledby} {...props}>
+        {restConmponents}
+      </BaseDatagrid>
     </DatagridWrapper>
   );
 };

--- a/packages/react-kit/src/core/Datagrid/index.tsx
+++ b/packages/react-kit/src/core/Datagrid/index.tsx
@@ -9,6 +9,7 @@ import DatagridBody, { DatagridBodyProps } from './DatagridBody';
 import DatagridCell, { DatagridCellProps } from './DatagridCell';
 import DatagridHeader, { DatagridHeaderProps } from './DatagridHeader';
 import DatagridRow, { DatagridRowProps } from './DatagridRow';
+import DatagridRowList, { DatagridRowListProps } from './DatagridRowList';
 import DatagridSubheader from './DatagridSubheader';
 
 type Props = {} & HTMLAttributes<HTMLDivElement> & SxProp;
@@ -74,6 +75,14 @@ export default Object.assign(Datagrid, {
   Subheader: DatagridSubheader,
   Body: DatagridBody,
   Row: DatagridRow,
+  RowList: DatagridRowList,
   Cell: DatagridCell,
 });
-export type { Props as DatagridProps, DatagridBodyProps, DatagridCellProps, DatagridHeaderProps, DatagridRowProps };
+export type {
+  Props as DatagridProps,
+  DatagridBodyProps,
+  DatagridCellProps,
+  DatagridHeaderProps,
+  DatagridRowProps,
+  DatagridRowListProps,
+};

--- a/packages/react-kit/src/core/Grid/index.tsx
+++ b/packages/react-kit/src/core/Grid/index.tsx
@@ -1,6 +1,6 @@
 import { SpaceKey } from '@teamturing/token-studio';
 import { forcePixelValue, isArray, isNullable } from '@teamturing/utils';
-import { HTMLAttributes, PropsWithChildren, Ref, forwardRef } from 'react';
+import { AriaAttributes, HTMLAttributes, PropsWithChildren, Ref, forwardRef } from 'react';
 import styled from 'styled-components';
 import { ResponsiveValue, variant } from 'styled-system';
 
@@ -16,7 +16,8 @@ type Props = {
    */
   layout?: boolean;
 } & Pick<ViewProps, 'alignItems' | 'justifyContent' | 'sx'> &
-  Pick<HTMLAttributes<HTMLDivElement>, 'className'> &
+  Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'id' | 'role' | 'tabIndex'> &
+  AriaAttributes &
   AsProp;
 
 const Grid = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
@@ -98,7 +99,8 @@ const BaseGrid = styled(View)<Omit<Props, 'wrap'> & { wrap?: ResponsiveValue<'tr
 type UnitSizeType = 'min' | 'max' | number;
 
 type GridUnitProps = { size: ResponsiveValue<UnitSizeType> } & Pick<ViewProps, 'order' | 'sx'> &
-  Pick<HTMLAttributes<HTMLDivElement>, 'className'> &
+  Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'id' | 'role' | 'tabIndex'> &
+  AriaAttributes &
   AsProp;
 
 const mapValueToResponsiveValueProps = <T,>(

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -72,6 +72,7 @@ export type {
   DatagridCellProps,
   DatagridHeaderProps,
   DatagridRowProps,
+  DatagridRowListProps,
 } from './core/Datagrid';
 
 export { default as DescriptionList } from './core/DescriptionList';


### PR DESCRIPTION
## 변경사항
- react-kit Datagrid에 ARIA table 시맨틱 부여 (role=table/rowgroup/row/cell, Header 자동 연결로 접근 가능한 이름 제공, Row/Cell columnHeader prop으로 열 헤더 지정)
- react-kit Datagrid.RowList 추가 — rows/columns 배열로 행을 선언적으로 렌더하고 rowProps로 DatagridRowProps 전체 제어
- react-kit Grid/Grid.Unit에 id/role/tabIndex/aria-* prop 전달 지원

🤖 Generated with [Claude Code](https://claude.com/claude-code)