### PR TITLE
react-kit 코어 컴포넌트 접근성(a11y)을 보강한다

### DIFF
--- a/packages/react-kit/src/core/ClickArea/index.tsx
+++ b/packages/react-kit/src/core/ClickArea/index.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, PropsWithChildren, Ref, forwardRef } from 'react';
+import { HTMLAttributes, KeyboardEvent, PropsWithChildren, Ref, forwardRef } from 'react';
 import styled from 'styled-components';
 
 import View, { ViewProps } from '../View';
@@ -8,20 +8,31 @@ type Props = {
 } & ViewProps &
   Pick<HTMLAttributes<HTMLDivElement>, 'onClick'>;
 
-const ClickArea = ({ disabled, onClick, ...props }: PropsWithChildren<Props>, ref: Ref<HTMLDivElement>) => (
-  <BaseClickArea
-    ref={ref}
-    {...props}
-    role={'button'}
-    aria-disabled={disabled}
-    disabled={disabled}
-    {...(!disabled
-      ? {
-          onClick,
-        }
-      : {})}
-  />
-);
+const ClickArea = ({ disabled, onClick, ...props }: PropsWithChildren<Props>, ref: Ref<HTMLDivElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.currentTarget.click();
+    }
+  };
+
+  return (
+    <BaseClickArea
+      ref={ref}
+      {...props}
+      role={'button'}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
+      disabled={disabled}
+      {...(!disabled
+        ? {
+            onClick,
+            onKeyDown: handleKeyDown,
+          }
+        : {})}
+    />
+  );
+};
 
 const BaseClickArea = styled(View)<Pick<Props, 'disabled'>>`
   &:hover {

--- a/packages/react-kit/src/core/DescriptionList/index.tsx
+++ b/packages/react-kit/src/core/DescriptionList/index.tsx
@@ -58,13 +58,13 @@ const DescriptionList = <
       return (
         <Grid gapX={gapX} gapY={gapY}>
           <Grid.Unit size={titleUnitSize}>
-            <View display={'flex'} alignItems={'center'} flexWrap={'nowrap'} sx={{ columnGap: 1 }}>
+            <View role={'term'} display={'flex'} alignItems={'center'} flexWrap={'nowrap'} sx={{ columnGap: 1 }}>
               {icon ? <StyledIcon icon={icon} size={16} color={'icon/neutral'} /> : null}
               {renderTitle(title)}
             </View>
           </Grid.Unit>
           <Grid.Unit size={descriptionUnitSize}>
-            {renderDescription(!isNullable(description) ? description : '-')}
+            <View role={'definition'}>{renderDescription(!isNullable(description) ? description : '-')}</View>
           </Grid.Unit>
         </Grid>
       );

--- a/packages/react-kit/src/core/Dialog/index.tsx
+++ b/packages/react-kit/src/core/Dialog/index.tsx
@@ -236,6 +236,7 @@ const Dialog = (
                     icon={CloseIcon}
                     variant={'plain-bold'}
                     size={'m'}
+                    aria-label={theme.locales?.Dialog?.closeButtonLabel ?? '닫기'}
                     onClick={handleDismiss}
                   />
                 </View>

--- a/packages/react-kit/src/core/Drawer/index.tsx
+++ b/packages/react-kit/src/core/Drawer/index.tsx
@@ -190,6 +190,7 @@ const Drawer = (
                   icon={CloseIcon}
                   variant={'plain-bold'}
                   size={'m'}
+                  aria-label={theme.locales?.Drawer?.closeButtonLabel ?? '닫기'}
                   onClick={handleDismiss}
                 />
               </View>

--- a/packages/react-kit/src/core/Drawer/index.tsx
+++ b/packages/react-kit/src/core/Drawer/index.tsx
@@ -3,6 +3,7 @@ import { forcePixelValue } from '@teamturing/utils';
 import { easeInOut } from 'framer-motion';
 import {
   forwardRef,
+  HTMLAttributes,
   PropsWithChildren,
   Ref,
   RefObject,
@@ -39,7 +40,8 @@ type Props = {
   size?: DrawerSizeType;
   direction?: DrawerDirectionType;
   initialFocusRef?: RefObject<HTMLElement>;
-} & SxProp;
+} & Pick<HTMLAttributes<HTMLDivElement>, 'aria-label' | 'aria-labelledby'> &
+  SxProp;
 
 const Drawer = (
   {
@@ -50,6 +52,8 @@ const Drawer = (
     size = 'm',
     direction = 'right',
     initialFocusRef,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
     sx,
   }: PropsWithChildren<Props>,
   ref: Ref<HTMLDivElement>,
@@ -91,7 +95,12 @@ const Drawer = (
     [handleDismiss],
   );
 
-  useFocusTrap({ containerRef: drawerRef, initialFocusRef: initialFocusRef || closeButtonRef, disabled: !isOpen });
+  useFocusTrap({
+    containerRef: drawerRef,
+    initialFocusRef: initialFocusRef || closeButtonRef,
+    disabled: !isOpen,
+    restoreFocusOnCleanUp: true,
+  });
 
   useEffect(() => {
     if (isOpen && isOutsideClickDismissable) {
@@ -165,6 +174,8 @@ const Drawer = (
               className={`trk-drawer--${size} trk-drawer--${direction}`}
               ref={drawerRef}
               aria-modal={'true'}
+              aria-label={ariaLabel}
+              aria-labelledby={ariaLabelledby}
               role={'dialog'}
               tabIndex={-1}
               size={size}

--- a/packages/react-kit/src/core/Flash/index.tsx
+++ b/packages/react-kit/src/core/Flash/index.tsx
@@ -46,8 +46,14 @@ const Flash = (
 ) => {
   const isButtonExist = !isNullable(buttons) && buttons.length > 0;
   return (
-    <BaseFlash ref={ref} variant={variant} {...props}>
-      <Icon className={'flash__leading_icon'} />
+    <BaseFlash
+      ref={ref}
+      variant={variant}
+      role={variant === 'danger' ? 'alert' : 'status'}
+      aria-live={variant === 'danger' ? 'assertive' : 'polite'}
+      {...props}
+    >
+      <Icon className={'flash__leading_icon'} aria-hidden={true} />
       <div className={'flash__content'}>
         <span className={'flash__content__children'}>{children}</span>
         {isButtonExist ? <div className={'flash__content__buttons'}>{buttons}</div> : null}

--- a/packages/react-kit/src/core/FormControl/FormControlCaption.tsx
+++ b/packages/react-kit/src/core/FormControl/FormControlCaption.tsx
@@ -7,10 +7,10 @@ import { FormControlContext } from '.';
 type Props = {};
 
 const FormControlCaption = ({ children }: PropsWithChildren<Props>) => {
-  const { id } = useContext(FormControlContext);
+  const { captionId } = useContext(FormControlContext);
 
   return (
-    <Text as={'span'} id={id} typography={'xxs'} color={'text/neutral/subtlest'}>
+    <Text as={'span'} id={captionId} typography={'xxs'} color={'text/neutral/subtlest'}>
       {children}
     </Text>
   );

--- a/packages/react-kit/src/core/FormControl/FormControlErrorMessage.tsx
+++ b/packages/react-kit/src/core/FormControl/FormControlErrorMessage.tsx
@@ -8,10 +8,10 @@ import { FormControlContext } from '.';
 type Props = {};
 
 const FormControlErrorMessage = ({ children }: PropsWithChildren<Props>) => {
-  const { id } = useContext(FormControlContext);
+  const { errorId } = useContext(FormControlContext);
 
   return (
-    <StyledText id={id} typography={'xxs'} color={'text/danger'}>
+    <StyledText id={errorId} role={'alert'} typography={'xxs'} color={'text/danger'}>
       {children}
     </StyledText>
   );

--- a/packages/react-kit/src/core/FormControl/FormControlSuccessMessage.tsx
+++ b/packages/react-kit/src/core/FormControl/FormControlSuccessMessage.tsx
@@ -8,10 +8,10 @@ import { FormControlContext } from '.';
 type Props = {};
 
 const FormControlSuccessMessage = ({ children }: PropsWithChildren<Props>) => {
-  const { id } = useContext(FormControlContext);
+  const { successId } = useContext(FormControlContext);
 
   return (
-    <StyledText id={id} typography={'xxs'} color={'text/success'}>
+    <StyledText id={successId} role={'status'} typography={'xxs'} color={'text/success'}>
       {children}
     </StyledText>
   );

--- a/packages/react-kit/src/core/FormControl/index.tsx
+++ b/packages/react-kit/src/core/FormControl/index.tsx
@@ -1,4 +1,13 @@
-import { PropsWithChildren, ReactElement, Ref, cloneElement, createContext, forwardRef, isValidElement } from 'react';
+import {
+  PropsWithChildren,
+  ReactElement,
+  Ref,
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useId,
+} from 'react';
 
 import useRelocation from '../../hook/useRelocation';
 import Checkbox from '../Checkbox';
@@ -46,7 +55,14 @@ type FormControlFieldProps = {
   caption?: string;
 };
 
-type FormControlContextValue = {} & Omit<Props, 'additionalInputComponentCandidates'>;
+type FormControlContextValue = {
+  /**
+   * `Caption`, `ErrorMessage`, `SuccessMessage`가 Input과 `aria-describedby`로 연결되기 위한 고유 ID입니다.
+   */
+  captionId?: string;
+  errorId?: string;
+  successId?: string;
+} & Omit<Props, 'additionalInputComponentCandidates'>;
 const FormControlContext = createContext<FormControlContextValue>({});
 
 const FormControl = (
@@ -88,11 +104,32 @@ const FormControl = (
     isValidElement(InputComponent) &&
     (InputComponent.type === Checkbox || InputComponent.type === Radio || InputComponent.type === Switch);
 
+  const reactId = useId();
+  const resolvedId = id ?? reactId;
+  const captionId = `${resolvedId}-caption`;
+  const errorId = `${resolvedId}-error`;
+  const successId = `${resolvedId}-success`;
+
+  const hasCaption = Boolean(relocatableComponentsObject.caption);
+  const hasError = Boolean(relocatableComponentsObject.errorMessage);
+  const hasSuccess = Boolean(relocatableComponentsObject.successMessage);
+
+  const describedBy =
+    [hasCaption && captionId, hasError && errorId, hasSuccess && successId].filter(Boolean).join(' ') || undefined;
+
+  const inputA11yProps = {
+    'id': resolvedId,
+    disabled,
+    'aria-invalid': hasError ? true : undefined,
+    'aria-required': required ? true : undefined,
+    'aria-describedby': describedBy,
+  };
+
   return (
-    <FormControlContext.Provider value={{ id, disabled, required }}>
+    <FormControlContext.Provider value={{ id: resolvedId, disabled, required, captionId, errorId, successId }}>
       {isHorizontalLayoutNeeded ? (
         <View ref={ref} display={'flex'} sx={{ columnGap: 2, ...sx }} {...props}>
-          <View display={'inline-flex'}>{cloneElement(InputComponent as ReactElement, { id, disabled })}</View>
+          <View display={'inline-flex'}>{cloneElement(InputComponent as ReactElement, inputA11yProps)}</View>
           <View sx={{ '& > span': { mt: 0.5 } }}>
             <View
               className={'form_control__label_wrapper__horizontal'}
@@ -131,7 +168,7 @@ const FormControl = (
             {relocatableComponentsObject.label}
             {relocatableComponentsObject.tooltipIcon}
           </View>
-          {cloneElement(InputComponent as ReactElement, { id, disabled })}
+          {cloneElement(InputComponent as ReactElement, inputA11yProps)}
           {relocatableComponentsObject.caption}
           {relocatableComponentsObject.errorMessage}
           {relocatableComponentsObject.successMessage}

--- a/packages/react-kit/src/core/FormControl/index.tsx
+++ b/packages/react-kit/src/core/FormControl/index.tsx
@@ -114,14 +114,23 @@ const FormControl = (
   const hasError = Boolean(relocatableComponentsObject.errorMessage);
   const hasSuccess = Boolean(relocatableComponentsObject.successMessage);
 
+  /**
+   * 소비자가 Input에 직접 전달한 aria 값을 보존하기 위해 기존 props와 병합합니다.
+   */
+  const inputProps: Record<string, any> = isValidElement(InputComponent)
+    ? (InputComponent.props as Record<string, any>)
+    : {};
+
   const describedBy =
-    [hasCaption && captionId, hasError && errorId, hasSuccess && successId].filter(Boolean).join(' ') || undefined;
+    [inputProps['aria-describedby'], hasCaption && captionId, hasError && errorId, hasSuccess && successId]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   const inputA11yProps = {
     'id': resolvedId,
     disabled,
-    'aria-invalid': hasError ? true : undefined,
-    'aria-required': required ? true : undefined,
+    'aria-invalid': hasError ? true : inputProps['aria-invalid'],
+    'aria-required': required ? true : inputProps['aria-required'],
     'aria-describedby': describedBy,
   };
 

--- a/packages/react-kit/src/core/IconButton/index.tsx
+++ b/packages/react-kit/src/core/IconButton/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, Ref, SVGProps, forwardRef } from 'react';
+import { ComponentType, Ref, SVGProps, forwardRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { ResponsiveValue, variant } from 'styled-system';
 
@@ -47,6 +47,16 @@ const IconButton = forwardRef<HTMLButtonElement, Props>(
     { icon: Icon, size = 'm', variant = 'primary', disabled = false, loading = false, ...props },
     ref: Ref<HTMLButtonElement>,
   ) => {
+    const hasAccessibleName = Boolean(props['aria-label'] || props['aria-labelledby'] || props['title']);
+    useEffect(() => {
+      if (process.env.NODE_ENV !== 'production' && !hasAccessibleName) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'IconButton: An icon-only button should provide an accessible name via `aria-label`, `aria-labelledby`, or `title` so that assistive technologies can identify it.',
+        );
+      }
+    }, [hasAccessibleName]);
+
     return (
       <BaseIconButton
         ref={ref}

--- a/packages/react-kit/src/core/IconToggleButton/index.tsx
+++ b/packages/react-kit/src/core/IconToggleButton/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, Ref, SVGProps, forwardRef } from 'react';
+import { ComponentType, Ref, SVGProps, forwardRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { ResponsiveValue, variant } from 'styled-system';
 
@@ -50,23 +50,36 @@ const IconToggleButton = (
     ...props
   }: Props,
   ref: Ref<HTMLButtonElement>,
-) => (
-  <BaseIconToggleButton
-    ref={ref}
-    icon={Icon}
-    size={size}
-    shape={shape}
-    variant={variant}
-    selected={selected}
-    type={'button'}
-    disabled={disabled}
-    $disabled={disabled}
-    sx={sx}
-    {...props}
-  >
-    <Icon />
-  </BaseIconToggleButton>
-);
+) => {
+  const hasAccessibleName = Boolean(props['aria-label'] || props['aria-labelledby'] || props['title']);
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && !hasAccessibleName) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'IconToggleButton: An icon-only button should provide an accessible name via `aria-label`, `aria-labelledby`, or `title` so that assistive technologies can identify it.',
+      );
+    }
+  }, [hasAccessibleName]);
+
+  return (
+    <BaseIconToggleButton
+      ref={ref}
+      icon={Icon}
+      size={size}
+      shape={shape}
+      variant={variant}
+      selected={selected}
+      aria-pressed={selected}
+      type={'button'}
+      disabled={disabled}
+      $disabled={disabled}
+      sx={sx}
+      {...props}
+    >
+      <Icon />
+    </BaseIconToggleButton>
+  );
+};
 
 const BaseIconToggleButton = styled(UnstyledButton)<Props & { $disabled?: boolean }>(
   ({ $disabled, theme }) => ({

--- a/packages/react-kit/src/core/Overlay/index.tsx
+++ b/packages/react-kit/src/core/Overlay/index.tsx
@@ -111,7 +111,7 @@ const Overlay = (
   }, [isOpen, handleOutsideClick]);
 
   return isOpen ? (
-    <BaseOverlay ref={overlayRef} size={size} maxHeight={maxHeight} {...props} role={'dialog'}>
+    <BaseOverlay ref={overlayRef} role={'dialog'} size={size} maxHeight={maxHeight} {...props}>
       {children}
     </BaseOverlay>
   ) : null;

--- a/packages/react-kit/src/core/SearchSelectInput/index.tsx
+++ b/packages/react-kit/src/core/SearchSelectInput/index.tsx
@@ -199,7 +199,7 @@ const SearchSelectInput = <T,>(
         </Overlay>
       )}
     >
-      {(popperProps) => (
+      {(popperProps, { isOpen }) => (
         <TextInputWrapper
           {...(disabled
             ? {}
@@ -260,6 +260,9 @@ const SearchSelectInput = <T,>(
             <BaseInput
               id={id}
               ref={labelInputRef}
+              role={'combobox'}
+              aria-haspopup={'listbox'}
+              aria-expanded={isOpen}
               readOnly
               onChange={noop}
               autoComplete={'off'}

--- a/packages/react-kit/src/core/Spinner/index.tsx
+++ b/packages/react-kit/src/core/Spinner/index.tsx
@@ -4,7 +4,15 @@ import styled, { keyframes, useTheme } from 'styled-components';
 
 type SpinnerVariantType = 'progress-gradient' | 'progress-line';
 
-type Props = { variant?: SpinnerVariantType } & Omit<SVGProps<SVGSVGElement>, 'ref'>;
+type Props = {
+  variant?: SpinnerVariantType;
+  /**
+   * 스크린 리더에 읽힐 로딩 상태 텍스트를 정의합니다.
+   * 빈 문자열(`''`)을 전달하면 장식용으로 간주되어 보조 기술에서 숨겨집니다.
+   * @default '로딩 중'
+   */
+  label?: string;
+} & Omit<SVGProps<SVGSVGElement>, 'ref'>;
 
 const spin = keyframes`
   from {
@@ -26,7 +34,7 @@ const ProgressLineSpinner = styled(ProgressLineIcon)`
 `;
 
 const Spinner = forwardRef<SVGSVGElement, Props>(
-  ({ variant: propsVariant, width = 32, height = 32, ...props }, ref) => {
+  ({ variant: propsVariant, width = 32, height = 32, label = '로딩 중', ...props }, ref) => {
     const theme = useTheme();
     const variant: SpinnerVariantType =
       propsVariant ?? theme.components?.spinner?.defaultVariant ?? 'progress-gradient';
@@ -35,7 +43,11 @@ const Spinner = forwardRef<SVGSVGElement, Props>(
       'progress-line': ProgressLineSpinner,
     }[variant];
 
-    return <SpinnerComponent ref={ref} width={width} height={height} {...props} />;
+    const a11yProps: Pick<SVGProps<SVGSVGElement>, 'role' | 'aria-label' | 'aria-busy' | 'aria-hidden'> = label
+      ? { 'role': 'status', 'aria-label': label, 'aria-busy': true }
+      : { 'aria-hidden': true };
+
+    return <SpinnerComponent ref={ref} width={width} height={height} {...a11yProps} {...props} />;
   },
 );
 

--- a/packages/react-kit/src/core/StyledIcon/index.tsx
+++ b/packages/react-kit/src/core/StyledIcon/index.tsx
@@ -8,20 +8,34 @@ type Props = {
    */
   icon: ComponentType<SVGProps<SVGSVGElement>>;
 } & Pick<ViewProps, 'size' | 'color' | 'sx'> &
-  Pick<HTMLAttributes<HTMLDivElement>, 'className'>;
+  Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'aria-label' | 'aria-hidden'>;
 
 const StyledIcon = forwardRef<HTMLDivElement, Props>(
-  ({ icon: Icon, sx, className, ...props }, ref: Ref<HTMLDivElement>) => (
-    <View
-      ref={ref}
-      {...props}
-      className={`trk-styled_icon__wrapper ${className}`}
-      color={props.color as any}
-      sx={{ '& svg': { display: 'inline-flex', width: '100%', height: '100%' }, ...sx }}
-    >
-      <Icon />
-    </View>
-  ),
+  (
+    { 'icon': Icon, sx, className, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden, ...props },
+    ref: Ref<HTMLDivElement>,
+  ) => {
+    /**
+     * 기본적으로 장식용 아이콘으로 간주해 `aria-hidden`을 부여합니다.
+     * 의미 있는 아이콘이라면 `aria-label`을 전달하세요. (`role="img"`로 노출됩니다.)
+     */
+    const a11yProps = ariaLabel
+      ? { 'role': 'img' as const, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden }
+      : { 'aria-hidden': ariaHidden ?? true };
+
+    return (
+      <View
+        ref={ref}
+        {...props}
+        {...a11yProps}
+        className={`trk-styled_icon__wrapper ${className}`}
+        color={props.color as any}
+        sx={{ '& svg': { display: 'inline-flex', width: '100%', height: '100%' }, ...sx }}
+      >
+        <Icon />
+      </View>
+    );
+  },
 );
 
 export default StyledIcon;

--- a/packages/react-kit/src/core/Switch/index.tsx
+++ b/packages/react-kit/src/core/Switch/index.tsx
@@ -12,7 +12,9 @@ type Props = {
 
 const Switch = ({ checked, validationStatus, ...props }: Props, ref: Ref<HTMLInputElement>) => {
   const checkboxRef = useProvidedOrCreatedRef(ref as React.RefObject<HTMLInputElement>);
-  return <BaseSwitch ref={checkboxRef} checked={checked} validationStatus={validationStatus} {...props} />;
+  return (
+    <BaseSwitch ref={checkboxRef} role={'switch'} checked={checked} validationStatus={validationStatus} {...props} />
+  );
 };
 
 const UnstyledSwitch = styled.input.attrs({ type: 'checkbox' })<SxProp>`

--- a/packages/react-kit/src/core/Tab/TabItem.tsx
+++ b/packages/react-kit/src/core/Tab/TabItem.tsx
@@ -47,6 +47,7 @@ const TabItem = ({
       className={'trk-tab_item'}
       type={'button'}
       role={'tab'}
+      aria-selected={selected}
       ref={ref}
       variant={variant}
       size={size}

--- a/packages/react-kit/src/core/Tab/index.tsx
+++ b/packages/react-kit/src/core/Tab/index.tsx
@@ -120,7 +120,13 @@ const Tab = ({ variant = 'plain', size = 'm', gap = 2, sx, children }: PropsWith
                   backgroundColor: theme.colors.surface,
                 }}
               >
-                <IconButton size={'s'} variant={'plain-bold'} icon={ChevronLeftIcon} onClick={handleLeftButtonClick} />
+                <IconButton
+                  size={'s'}
+                  variant={'plain-bold'}
+                  icon={ChevronLeftIcon}
+                  aria-label={theme.locales?.Tab?.scrollLeftLabel ?? '왼쪽으로 스크롤'}
+                  onClick={handleLeftButtonClick}
+                />
               </View>
             </>
           ) : null}
@@ -155,6 +161,7 @@ const Tab = ({ variant = 'plain', size = 'm', gap = 2, sx, children }: PropsWith
                   size={'s'}
                   variant={'plain-bold'}
                   icon={ChevronRightIcon}
+                  aria-label={theme.locales?.Tab?.scrollRightLabel ?? '오른쪽으로 스크롤'}
                   onClick={handleRightButtonClick}
                 />
               </View>

--- a/packages/react-kit/src/core/Toast/index.tsx
+++ b/packages/react-kit/src/core/Toast/index.tsx
@@ -1,5 +1,5 @@
 import { CheckInCircleIcon, ExclamationPointInCircleIcon } from '@teamturing/icons';
-import { ComponentType, PropsWithChildren, SVGProps } from 'react';
+import { ComponentType, HTMLAttributes, PropsWithChildren, SVGProps } from 'react';
 import styled from 'styled-components';
 import { ResponsiveValue, variant } from 'styled-system';
 
@@ -21,17 +21,24 @@ type Props = {
    * 반응형 디자인이 적용됩니다.
    */
   resizing?: ResponsiveValue<'hug' | 'fill'>;
-};
+} & HTMLAttributes<HTMLDivElement>;
 
 const Toast = ({
   variant = 'success',
   icon: Icon = variant === 'success' ? CheckInCircleIcon : ExclamationPointInCircleIcon,
   resizing = 'hug',
   children,
+  ...props
 }: PropsWithChildren<Props>) => {
   return (
-    <BaseToast variant={variant} resizing={resizing}>
-      <Icon className={'toast__leading_icon'} />
+    <BaseToast
+      variant={variant}
+      resizing={resizing}
+      role={variant === 'warning' ? 'alert' : 'status'}
+      aria-live={variant === 'warning' ? 'assertive' : 'polite'}
+      {...props}
+    >
+      <Icon className={'toast__leading_icon'} aria-hidden={true} />
       {children}
     </BaseToast>
   );

--- a/packages/react-kit/src/theme/index.ts
+++ b/packages/react-kit/src/theme/index.ts
@@ -36,6 +36,9 @@ const theme = {
     Pagination: { previous: '이전', next: '다음' },
     Select: { placeholder: '옵션 선택' },
     UploadInput: { placeholder: '파일을 끌어다 놓으세요', selectFile: '파일 선택' },
+    Dialog: { closeButtonLabel: '닫기' },
+    Drawer: { closeButtonLabel: '닫기' },
+    Tab: { scrollLeftLabel: '왼쪽으로 스크롤', scrollRightLabel: '오른쪽으로 스크롤' },
   },
 };
 


### PR DESCRIPTION
## 변경사항

`packages/react-kit`의 코어 컴포넌트를 전수 점검하고, 접근성이 미흡한 컴포넌트들을 우선순위별로 보강했습니다. 모두 안전한 기본값/가산적 방식이라 기존 사용처를 깨지 않습니다.

### 우선순위 1 — 즉시 (스크린리더 차단급)
- **Toast / Flash / Spinner**: variant별 `role`(status/alert) + `aria-live` 기본값, 리딩 아이콘 `aria-hidden`. Spinner는 `label` prop(기본 '로딩 중')로 `role="status"`+`aria-busy` 노출
- **ClickArea**: `tabIndex` + `Enter`/`Space` 키보드 핸들러 추가 (키보드 조작 불가 문제 해소)
- **FormControl**: Label/Caption/Error/Success와 Input을 `aria-describedby`/`aria-invalid`/`aria-required`로 연결. 메시지들이 Input과 동일한 `id`를 공유하던 **중복 id 버그 수정**, `useId()`로 id 자동 생성. Error/Success에 `role="alert"`/`role="status"`

### 우선순위 2 — 중간
- **Switch**: `role="switch"` (상태는 native checked→aria-checked 자동)
- **IconButton / IconToggleButton**: IconToggleButton `aria-pressed`, 접근명 누락 시 개발 환경 경고
- **Tab.Item**: `aria-selected`
- **Drawer**: 닫을 때 포커스 복원(`restoreFocusOnCleanUp`) + `aria-label` 패스스루
- **Overlay**: `role`이 `{...props}`에 가려 override 불가하던 버그 수정(비-dialog 용도 지원)

### 우선순위 3 — 낮음
- **StyledIcon**: `aria-hidden` 기본화(장식용), `aria-label` 시 `role="img"` 노출
- **SearchSelectInput**: 트리거에 `role="combobox"`+`aria-haspopup`+`aria-expanded`
- **DescriptionList**: title/description에 `role="term"`/`role="definition"`

## 검증
- `tsc --noEmit` 에러 0, `eslint` 통과
- 정적 분석까지 확인. 실제 DOM 출력(스크린리더 announce 등) 런타임 확인은 별도 필요

## Follow-up (이번 범위 밖)
- SearchSelectInput 완전 combobox 패턴(listbox/option/activedescendant) — 소비자 API 협의 필요
- FileItem img/video alt·상태 아이콘 라벨
- DescriptionList native `<dl>` 리팩터(원할 경우)

🤖 Generated with [Claude Code](https://claude.com/claude-code)