### PR TITLE
Deploy 🧩

### DIFF
--- a/packages/react-kit/src/core/ClickArea/index.tsx
+++ b/packages/react-kit/src/core/ClickArea/index.tsx
@@ -1,11 +1,13 @@
 import { HTMLAttributes, KeyboardEvent, PropsWithChildren, Ref, forwardRef } from 'react';
 import styled from 'styled-components';
 
+import { CursorProps, cursor } from '../../utils/styled-system';
 import View, { ViewProps } from '../View';
 
 type Props = {
   disabled?: boolean;
-} & ViewProps &
+} & CursorProps &
+  ViewProps &
   Pick<HTMLAttributes<HTMLDivElement>, 'onClick'>;
 
 const ClickArea = ({ disabled, onClick, ...props }: PropsWithChildren<Props>, ref: Ref<HTMLDivElement>) => {
@@ -34,10 +36,10 @@ const ClickArea = ({ disabled, onClick, ...props }: PropsWithChildren<Props>, re
   );
 };
 
-const BaseClickArea = styled(View)<Pick<Props, 'disabled'>>`
-  &:hover {
-    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  }
+const BaseClickArea = styled(View).attrs<Pick<Props, 'disabled' | 'cursor'>>(({ disabled, cursor }) => ({
+  cursor: disabled ? 'not-allowed' : cursor ?? 'pointer',
+}))`
+  ${cursor}
 `;
 
 export default forwardRef(ClickArea);

--- a/packages/react-kit/src/core/TextTruncate/index.tsx
+++ b/packages/react-kit/src/core/TextTruncate/index.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { MaxWidthProps, maxWidth } from 'styled-system';
+
+import { LineClampProps, SxProp, lineClamp, sx } from '../../utils/styled-system';
+
+type Props = {} & MaxWidthProps & LineClampProps & SxProp;
+
+const TextTruncate = styled.div<Props>`
+  ${maxWidth}
+  ${lineClamp}
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+
+  ${sx}
+`;
+
+export default TextTruncate;
+export type { Props as TextTruncateProps };

--- a/packages/react-kit/src/core/UploadInput/index.tsx
+++ b/packages/react-kit/src/core/UploadInput/index.tsx
@@ -39,20 +39,16 @@ const UploadInput = (
   };
   const handleDrop: DragEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault();
+    e.currentTarget?.classList.remove('upload-input__wrapper__active');
 
     const files = e.dataTransfer?.files ?? [];
     if (files.length < 1) return;
-    if (!props.multiple && files.length > 1) {
-      e.currentTarget?.classList.remove('upload-input__wrapper__active');
-      return;
-    }
+    if (!props.multiple && files.length > 1) return;
 
     const isAcceptableFile = new RegExp(
       (accept || '*').replace(/\*/g, '.*').replace(/,/g, '|').replace(/\s/g, ''),
     ).test(files[0].type);
     if (!isAcceptableFile) return;
-
-    e.currentTarget?.classList.remove('upload-input__wrapper__active');
 
     if (inputRef && inputRef.current && files) {
       const currentFiles = inputRef.current.files;

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -191,6 +191,9 @@ export type { TabProps } from './core/Tab';
 export { default as Text } from './core/Text';
 export type { TextProps } from './core/Text';
 
+export { default as TextTruncate } from './core/TextTruncate';
+export type { TextTruncateProps } from './core/TextTruncate';
+
 export { default as Textarea } from './core/Textarea';
 export type { TextareaProps } from './core/Textarea';
 

--- a/packages/react-kit/src/utils/styled-system/index.ts
+++ b/packages/react-kit/src/utils/styled-system/index.ts
@@ -39,6 +39,11 @@ type LineClampProps<ThemeType extends Theme = RequiredTheme> = {
 };
 const lineClamp = system({ lineClamp: { property: 'WebkitLineClamp', scale: 'WebkitLineClamp' } });
 
+type CursorProps<ThemeType extends Theme = RequiredTheme> = {
+  cursor?: ResponsiveValue<CSS.Property.Cursor, ThemeType> | undefined;
+};
+const cursor = system({ cursor: { property: 'cursor' } });
+
 type GapProps<ThemeType extends Theme = RequiredTheme, TVal = ThemeValue<'space', ThemeType>> = {
   gap?: ResponsiveValue<TVal, ThemeType> | undefined;
 };
@@ -54,7 +59,7 @@ type RowGapProps<ThemeType extends Theme = RequiredTheme, TVal = ThemeValue<'spa
 };
 const rowGap = system({ rowGap: { property: 'rowGap', scale: 'space' } });
 
-export { sx, textDecoration, whiteSpace, wordBreak, lineClamp, gap, columnGap, rowGap };
+export { sx, textDecoration, whiteSpace, wordBreak, lineClamp, cursor, gap, columnGap, rowGap };
 export type {
   BetterSystemStyleObject,
   AsProp,
@@ -62,6 +67,7 @@ export type {
   WhiteSpaceProps,
   WordBreakProps,
   LineClampProps,
+  CursorProps,
   GapProps,
   ColumnGapProps,
   RowGapProps,


### PR DESCRIPTION
## 변경사항
- react-kit ClickArea: `cursor` prop 지원 (styled-system 기반 responsive value, `disabled` 시 `not-allowed` 우선)
- react-kit TextTruncate 컴포넌트 추가 (maxWidth/lineClamp 기반 말줄임 프리미티브)
- react-kit UploadInput: accept 미허용/빈 파일 드롭 시 드래그 하이라이트가 남던 시각 버그 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)