### PR TITLE
Deploy 🔘

### DIFF
--- a/packages/react-kit/src/core/CheckboxGroup/CheckboxGroupOption.tsx
+++ b/packages/react-kit/src/core/CheckboxGroup/CheckboxGroupOption.tsx
@@ -1,9 +1,34 @@
-import { ChangeEvent, PropsWithChildren, ReactNode, Ref, forwardRef } from 'react';
+import { ChangeEvent, ReactNode, Ref, forwardRef } from 'react';
 
+import useFocusVisible from '../../hook/useFocusVisible';
 import Checkbox, { CheckboxProps } from '../Checkbox';
 import FormControl from '../FormControl';
+import View from '../View';
+import VisuallyHidden from '../_VisuallyHidden';
 
 import { useCheckboxGroupContext } from '.';
+
+/**
+ * 커스텀 시각을 그릴 때 render 함수로 전달되는 옵션 상태
+ */
+type CheckboxGroupOptionRenderState = {
+  /**
+   * 이 옵션이 선택되었는지 여부
+   */
+  checked: boolean;
+  /**
+   * 이 옵션이 비활성화되었는지 여부
+   */
+  disabled: boolean;
+  /**
+   * 키보드 포커스(`:focus-visible`) 여부. 커스텀 시각이 포커스 링을 그릴 때 사용한다.
+   */
+  focused: boolean;
+  /**
+   * 이 옵션이 속한 그룹이 필수 입력인지 여부
+   */
+  required: boolean;
+};
 
 type CheckboxGroupOptionProps = {
   /**
@@ -23,8 +48,13 @@ type CheckboxGroupOptionProps = {
    * 개별 onChange 핸들러 (CheckboxGroup의 onChange와 함께 호출됨)
    */
   onChange?: (value: string | number | boolean, e: ChangeEvent<HTMLInputElement>) => void;
-} & PropsWithChildren &
-  Omit<CheckboxProps, 'name' | 'checked' | 'onChange' | 'disabled'>;
+  /**
+   * 옵션의 시각 표현.
+   * - `ReactNode`: 기본 조합(`Checkbox` + `FormControl.Label`)의 label로 사용된다.
+   * - render 함수(`(state) => ReactNode`): 접근성을 유지한 채(sr-only 네이티브 checkbox) 커스텀 시각을 그린다.
+   */
+  children?: ReactNode | ((state: CheckboxGroupOptionRenderState) => ReactNode);
+} & Omit<CheckboxProps, 'name' | 'checked' | 'onChange' | 'disabled' | 'children'>;
 
 const CheckboxGroupOption = (
   {
@@ -44,11 +74,12 @@ const CheckboxGroupOption = (
     disabled: groupDisabled,
     required,
   } = useCheckboxGroupContext();
+  const { focused, onFocus, onBlur } = useFocusVisible();
 
   // CheckboxGroup의 value 배열에 현재 value가 포함되어 있는지 확인
   const checked = groupValue ? groupValue.includes(value) : false;
-  const disabled = groupDisabled || optionDisabled;
-  const displayLabel = children || label;
+  const disabled = Boolean(groupDisabled || optionDisabled);
+  const isRequired = Boolean(required);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     // CheckboxGroup의 onChange 호출
@@ -57,11 +88,44 @@ const CheckboxGroupOption = (
     onOptionChange?.(value, e);
   };
 
+  // 커스텀 시각 모드: 네이티브 checkbox는 sr-only로 숨겨 접근성(role/키보드/form 참여)을 유지하고,
+  // 시각 표현만 render 함수에 위임한다. label 래핑으로 클릭·접근 가능한 이름을 연결한다.
+  if (typeof children === 'function') {
+    return (
+      <View as={'label'} display={'inline-flex'} sx={{ cursor: disabled ? 'not-allowed' : 'pointer' }}>
+        <VisuallyHidden>
+          <Checkbox
+            ref={ref}
+            name={name}
+            value={String(value)}
+            checked={checked}
+            aria-label={typeof label === 'string' ? label : undefined}
+            {...checkboxProps}
+            disabled={disabled}
+            required={isRequired}
+            onChange={handleChange}
+            onFocus={(e) => {
+              checkboxProps.onFocus?.(e);
+              onFocus(e);
+            }}
+            onBlur={(e) => {
+              checkboxProps.onBlur?.(e);
+              onBlur();
+            }}
+          />
+        </VisuallyHidden>
+        {children({ checked, disabled, focused, required: isRequired })}
+      </View>
+    );
+  }
+
+  const displayLabel = children || label;
+
   // FormControl ID 생성 (접근성)
   const formControlId = name ? `${name}-${value}` : String(value);
 
   return (
-    <FormControl id={formControlId} disabled={disabled} required={required}>
+    <FormControl id={formControlId} disabled={disabled} required={isRequired}>
       <Checkbox
         ref={ref}
         name={name}
@@ -77,4 +141,4 @@ const CheckboxGroupOption = (
 };
 
 export default forwardRef(CheckboxGroupOption);
-export type { CheckboxGroupOptionProps };
+export type { CheckboxGroupOptionProps, CheckboxGroupOptionRenderState };

--- a/packages/react-kit/src/core/CheckboxGroup/index.tsx
+++ b/packages/react-kit/src/core/CheckboxGroup/index.tsx
@@ -3,7 +3,7 @@ import { ChangeEventHandler, Children, PropsWithChildren, ReactNode } from 'reac
 import { createSafeContext } from '../../utils/createSafeContext';
 import Grid from '../Grid';
 
-import CheckboxGroupOption, { CheckboxGroupOptionProps } from './CheckboxGroupOption';
+import CheckboxGroupOption, { CheckboxGroupOptionProps, CheckboxGroupOptionRenderState } from './CheckboxGroupOption';
 
 type CheckboxGroupContextValue = {
   name?: string;
@@ -76,4 +76,4 @@ const CheckboxGroup = ({
 
 export { useCheckboxGroupContext };
 export default Object.assign(CheckboxGroup, { Option: CheckboxGroupOption });
-export type { CheckboxGroupProps, CheckboxGroupContextValue, CheckboxGroupOptionProps };
+export type { CheckboxGroupProps, CheckboxGroupContextValue, CheckboxGroupOptionProps, CheckboxGroupOptionRenderState };

--- a/packages/react-kit/src/core/RadioGroup/RadioGroupOption.tsx
+++ b/packages/react-kit/src/core/RadioGroup/RadioGroupOption.tsx
@@ -1,9 +1,34 @@
-import { ChangeEvent, PropsWithChildren, ReactNode, Ref, forwardRef } from 'react';
+import { ChangeEvent, ReactNode, Ref, forwardRef } from 'react';
 
+import useFocusVisible from '../../hook/useFocusVisible';
 import FormControl from '../FormControl';
 import Radio, { RadioProps } from '../Radio';
+import View from '../View';
+import VisuallyHidden from '../_VisuallyHidden';
 
 import { useRadioGroupContext } from '.';
+
+/**
+ * 커스텀 시각을 그릴 때 render 함수로 전달되는 옵션 상태
+ */
+type RadioGroupOptionRenderState = {
+  /**
+   * 이 옵션이 선택되었는지 여부
+   */
+  checked: boolean;
+  /**
+   * 이 옵션이 비활성화되었는지 여부
+   */
+  disabled: boolean;
+  /**
+   * 키보드 포커스(`:focus-visible`) 여부. 커스텀 시각이 포커스 링을 그릴 때 사용한다.
+   */
+  focused: boolean;
+  /**
+   * 이 옵션이 속한 그룹이 필수 입력인지 여부
+   */
+  required: boolean;
+};
 
 type RadioGroupOptionProps = {
   /**
@@ -23,8 +48,13 @@ type RadioGroupOptionProps = {
    * 개별 onChange 핸들러 (RadioGroup의 onChange와 함께 호출됨)
    */
   onChange?: (value: string | number | boolean, e: ChangeEvent<HTMLInputElement>) => void;
-} & PropsWithChildren &
-  Omit<RadioProps, 'name' | 'checked' | 'onChange' | 'disabled'>;
+  /**
+   * 옵션의 시각 표현.
+   * - `ReactNode`: 기본 조합(`Radio` + `FormControl.Label`)의 label로 사용된다.
+   * - render 함수(`(state) => ReactNode`): 접근성을 유지한 채(sr-only 네이티브 radio) 커스텀 시각을 그린다.
+   */
+  children?: ReactNode | ((state: RadioGroupOptionRenderState) => ReactNode);
+} & Omit<RadioProps, 'name' | 'checked' | 'onChange' | 'disabled' | 'children'>;
 
 const RadioGroupOption = (
   { value, label, disabled: optionDisabled, onChange: onOptionChange, children, ...radioProps }: RadioGroupOptionProps,
@@ -37,10 +67,11 @@ const RadioGroupOption = (
     disabled: groupDisabled,
     required,
   } = useRadioGroupContext();
+  const { focused, onFocus, onBlur } = useFocusVisible();
 
   const checked = groupValue === value;
-  const disabled = groupDisabled || optionDisabled;
-  const displayLabel = children || label;
+  const disabled = Boolean(groupDisabled || optionDisabled);
+  const isRequired = Boolean(required);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     // RadioGroup의 onChange 호출
@@ -49,11 +80,44 @@ const RadioGroupOption = (
     onOptionChange?.(value, e);
   };
 
+  // 커스텀 시각 모드: 네이티브 radio는 sr-only로 숨겨 접근성(role/키보드/form 참여)을 유지하고,
+  // 시각 표현만 render 함수에 위임한다. label 래핑으로 클릭·접근 가능한 이름을 연결한다.
+  if (typeof children === 'function') {
+    return (
+      <View as={'label'} display={'inline-flex'} sx={{ cursor: disabled ? 'not-allowed' : 'pointer' }}>
+        <VisuallyHidden>
+          <Radio
+            ref={ref}
+            name={name}
+            value={String(value)}
+            checked={checked}
+            aria-label={typeof label === 'string' ? label : undefined}
+            {...radioProps}
+            disabled={disabled}
+            required={isRequired}
+            onChange={handleChange}
+            onFocus={(e) => {
+              radioProps.onFocus?.(e);
+              onFocus(e);
+            }}
+            onBlur={(e) => {
+              radioProps.onBlur?.(e);
+              onBlur();
+            }}
+          />
+        </VisuallyHidden>
+        {children({ checked, disabled, focused, required: isRequired })}
+      </View>
+    );
+  }
+
+  const displayLabel = children || label;
+
   // FormControl ID 생성 (접근성)
   const formControlId = name ? `${name}-${value}` : String(value);
 
   return (
-    <FormControl id={formControlId} disabled={disabled} required={required}>
+    <FormControl id={formControlId} disabled={disabled} required={isRequired}>
       <Radio
         ref={ref}
         name={name}
@@ -69,4 +133,4 @@ const RadioGroupOption = (
 };
 
 export default forwardRef(RadioGroupOption);
-export type { RadioGroupOptionProps };
+export type { RadioGroupOptionProps, RadioGroupOptionRenderState };

--- a/packages/react-kit/src/core/RadioGroup/index.tsx
+++ b/packages/react-kit/src/core/RadioGroup/index.tsx
@@ -3,7 +3,7 @@ import { ChangeEventHandler, Children, PropsWithChildren, ReactNode } from 'reac
 import { createSafeContext } from '../../utils/createSafeContext';
 import Grid from '../Grid';
 
-import RadioGroupOption, { RadioGroupOptionProps } from './RadioGroupOption';
+import RadioGroupOption, { RadioGroupOptionProps, RadioGroupOptionRenderState } from './RadioGroupOption';
 
 type RadioGroupContextValue = {
   name?: string;
@@ -76,4 +76,4 @@ const RadioGroup = ({
 
 export { useRadioGroupContext };
 export default Object.assign(RadioGroup, { Option: RadioGroupOption });
-export type { RadioGroupProps, RadioGroupContextValue, RadioGroupOptionProps };
+export type { RadioGroupProps, RadioGroupContextValue, RadioGroupOptionProps, RadioGroupOptionRenderState };

--- a/packages/react-kit/src/core/_VisuallyHidden/index.tsx
+++ b/packages/react-kit/src/core/_VisuallyHidden/index.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+/**
+ * 화면에서는 숨기지만 접근성 트리·탭 순서·포커스는 유지하는 래퍼.
+ *
+ * `display: none` / `visibility: hidden`과 달리 내부 요소가 포커스 가능한 상태로 남으므로,
+ * 커스텀 시각 뒤에 네이티브 컨트롤(radio/checkbox 등)을 숨겨둘 때 사용한다.
+ */
+const VisuallyHidden = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
+export default VisuallyHidden;

--- a/packages/react-kit/src/hook/useFocusVisible.ts
+++ b/packages/react-kit/src/hook/useFocusVisible.ts
@@ -1,0 +1,31 @@
+import { FocusEvent, useState } from 'react';
+
+/**
+ * 키보드 포커스(`:focus-visible`)만 추적하는 훅.
+ *
+ * 시각적으로 숨긴 네이티브 컨트롤(예: sr-only radio/checkbox) 위에 커스텀 시각을 그릴 때,
+ * 포커스 링을 커스텀 시각으로 옮기기 위해 사용한다. 마우스 클릭으로 인한 포커스는 제외된다.
+ */
+const isFocusVisible = (target: EventTarget & Element) => {
+  try {
+    return target.matches(':focus-visible');
+  } catch {
+    // `:focus-visible`을 지원하지 않는 환경에서는 보수적으로 포커스를 표시한다.
+    return true;
+  }
+};
+
+const useFocusVisible = () => {
+  const [focused, setFocused] = useState(false);
+
+  const onFocus = (e: FocusEvent<HTMLElement>) => {
+    if (isFocusVisible(e.target)) setFocused(true);
+  };
+  const onBlur = () => {
+    setFocused(false);
+  };
+
+  return { focused, onFocus, onBlur };
+};
+
+export default useFocusVisible;

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -43,7 +43,11 @@ export { default as Checkbox } from './core/Checkbox';
 export type { CheckboxProps } from './core/Checkbox';
 
 export { default as CheckboxGroup } from './core/CheckboxGroup';
-export type { CheckboxGroupProps, CheckboxGroupOptionProps } from './core/CheckboxGroup';
+export type {
+  CheckboxGroupProps,
+  CheckboxGroupOptionProps,
+  CheckboxGroupOptionRenderState,
+} from './core/CheckboxGroup';
 
 export { default as CheckboxOrRadioGroupFormControl } from './core/CheckboxOrRadioGroupFormControl';
 export type {
@@ -162,7 +166,7 @@ export { default as Radio } from './core/Radio';
 export type { RadioProps } from './core/Radio';
 
 export { default as RadioGroup } from './core/RadioGroup';
-export type { RadioGroupProps, RadioGroupOptionProps } from './core/RadioGroup';
+export type { RadioGroupProps, RadioGroupOptionProps, RadioGroupOptionRenderState } from './core/RadioGroup';
 
 export { default as SearchSelectInput } from './core/SearchSelectInput';
 export type { SearchSelectInputProps } from './core/SearchSelectInput';
@@ -230,6 +234,8 @@ export { default as useDelayedFunction } from './hook/useDelayedFunction';
 export { default as useDevice } from './hook/useDevice';
 
 export { default as useFocusTrap } from './hook/useFocusTrap';
+
+export { default as useFocusVisible } from './hook/useFocusVisible';
 
 export { default as useFocusZone } from './hook/useFocusZone';
 


### PR DESCRIPTION
## 변경사항
- react-kit RadioGroup/CheckboxGroup: `Option`의 `children`을 `(state) => ReactNode` render prop으로 오버로드해 커스텀 옵션 시각 지원. 시각적으로 숨긴 네이티브 radio/checkbox를 유지해 키보드 이동·roving focus·form 참여·required 검증·label 연결 등 접근성을 그대로 보존하고, `checked`/`disabled`/`focused`(키보드)/`required` 상태만 시각에 위임. 함수가 아닌 `children`은 기존 동작 유지(하위호환)
- react-kit: `useFocusVisible` 훅 추가(키보드 포커스만 추적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)