### PR TITLE
fix(react-kit): defer focusTrap activation to avoid scroll jump on reopen

### DIFF
--- a/packages/react-kit/src/hook/useFocusTrap.ts
+++ b/packages/react-kit/src/hook/useFocusTrap.ts
@@ -35,8 +35,14 @@ const useFocusTrap = (
   React.useEffect(() => {
     if (containerRef.current instanceof HTMLElement) {
       if (!disabled) {
-        abortController.current = focusTrap(containerRef.current, initialFocusRef.current ?? undefined);
+        // 위치(transform) 확정 전 focus 시 요소가 (0,0)이라 스크롤이 튀어 다음 프레임에 트랩을 켠다
+        const rafId = requestAnimationFrame(() => {
+          if (containerRef.current instanceof HTMLElement) {
+            abortController.current = focusTrap(containerRef.current, initialFocusRef.current ?? undefined);
+          }
+        });
         return () => {
+          cancelAnimationFrame(rafId);
           disableTrap();
         };
       } else {


### PR DESCRIPTION
## 문제
focus-trap 오버레이(OverlayPopper/Dialog/Drawer)를 같은 인스턴스로 재오픈하면 스크롤이 최상단으로 점프.

## 원인
재오픈 시 `isPositioned=true`인데 `transform`이 아직 DOM에 반영되기 전(요소가 (0,0)) focus-trap이 focus → 브라우저가 스크롤. `isPositioned` 게이팅의 한 프레임 갭.

## 해결
`useFocusTrap`이 `focusTrap()`을 `requestAnimationFrame`으로 미뤄 위치 확정 후 트랩을 켠다.

## 영향
Dialog/Drawer/OverlayPopper 초기 focus가 한 프레임 늦음. `useFocusZone`은 이미 `preventScroll`을 써서 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)