### PR TITLE
Deploy 🧭

### DIFF
--- a/packages/react-kit/src/core/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-kit/src/core/Breadcrumbs/BreadcrumbsItem.tsx
@@ -2,11 +2,12 @@ import { forcePixelValue } from '@teamturing/utils';
 import { AnchorHTMLAttributes, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 
-import { AsProp } from '../../utils/styled-system';
+import { AsProp, SxProp, sx } from '../../utils/styled-system';
 import Tooltip from '../Tooltip';
 
 type Props = { text: string; selected?: boolean; truncatedWidth?: number } & AnchorHTMLAttributes<HTMLAnchorElement> &
-  AsProp;
+  AsProp &
+  SxProp;
 
 const BreadcrumbsItem = ({ text, selected = false, truncatedWidth = 100, ...props }: Props) => {
   const itemRef = useRef<HTMLElement>(null);
@@ -21,7 +22,13 @@ const BreadcrumbsItem = ({ text, selected = false, truncatedWidth = 100, ...prop
   }, []);
 
   const baseBreadCrumbsItem = (
-    <BaseBreadcrumbsItem ref={itemRef} selected={selected} truncatedWidth={truncatedWidth} {...props}>
+    <BaseBreadcrumbsItem
+      className={'breadcrumbs_item'}
+      ref={itemRef}
+      selected={selected}
+      truncatedWidth={truncatedWidth}
+      {...props}
+    >
       {text}
     </BaseBreadcrumbsItem>
   );
@@ -61,6 +68,8 @@ const BaseBreadcrumbsItem = styled.a<Props>`
           pointer-events: none;
         `
       : ''}
+
+  ${sx}
 `;
 
 export default BreadcrumbsItem;

--- a/packages/react-kit/src/core/Breadcrumbs/index.tsx
+++ b/packages/react-kit/src/core/Breadcrumbs/index.tsx
@@ -2,6 +2,8 @@ import { forcePixelValue } from '@teamturing/utils';
 import { Children, PropsWithChildren, useState } from 'react';
 import styled from 'styled-components';
 
+import { AsProp, SxProp, sx } from '../../utils/styled-system';
+
 import BreadcrumbsItem from './BreadcrumbsItem';
 
 type Props = {
@@ -10,7 +12,8 @@ type Props = {
    * BreadcrumbsItem의 갯수가 maxItemCount보다 클 경우, 자동으로 중간 BreadcrumbsItem들을 줄여서 보여줍니다.
    */
   maxItemCount?: number;
-};
+} & SxProp &
+  AsProp;
 
 const Breadcrumbs = ({ children, maxItemCount = 5, ...props }: PropsWithChildren<Props>) => {
   const childrenArray = Children.toArray(children);
@@ -26,17 +29,19 @@ const Breadcrumbs = ({ children, maxItemCount = 5, ...props }: PropsWithChildren
       ];
 
   return (
-    <BaseBreadcrumbs aria-label={'Breadcrumb'} {...props}>
-      <BreadcrumbsList>
+    <BaseBreadcrumbs className={'breadcrumbs'} aria-label={'Breadcrumb'} {...props}>
+      <BreadcrumbsList className={'breadcrumbs__list'}>
         {Children.map(breadcrumbsItems, (child) => (
-          <BreadcrumbsItemWrapper>{child}</BreadcrumbsItemWrapper>
+          <BreadcrumbsItemWrapper className={'breadcrumbs__item_wrapper'}>{child}</BreadcrumbsItemWrapper>
         ))}
       </BreadcrumbsList>
     </BaseBreadcrumbs>
   );
 };
 
-const BaseBreadcrumbs = styled.nav``;
+const BaseBreadcrumbs = styled.nav<SxProp>`
+  ${sx}
+`;
 
 const BreadcrumbsList = styled.ol`
   display: flex;

--- a/packages/token-studio/src/token/index.ts
+++ b/packages/token-studio/src/token/index.ts
@@ -9,6 +9,7 @@ export type {
   IconColorKey,
   LinkColorKey,
   ScaleColorKey,
+  SurfaceColorKey,
   TextColorKey,
 } from './color';
 


### PR DESCRIPTION
* feat(react-kit): support sx, as, and className hooks in Breadcrumbs
* fix(token-studio): re-export SurfaceColorKey from token barrel