### PR TITLE
Deploy ↔️

### DIFF
--- a/packages/react-kit/src/core/Tab/index.tsx
+++ b/packages/react-kit/src/core/Tab/index.tsx
@@ -33,13 +33,15 @@ const Tab = ({ variant = 'plain', size = 'm', gap = 2, sx, children }: PropsWith
     rootRef.current ? rootRef.current.clientWidth + rootRef.current.scrollLeft < rootRef.current.scrollWidth : false,
   );
 
+  // 브라우저가 clientWidth/scrollWidth를 서로 다른 방향으로 정수화하면서(Safari, DPR > 1)
+  // 스크롤이 불필요한 경우에도 최대 1px 오차가 남기 때문에 임계값을 둔다
+  const scrollThreshold = 1;
+
   const handleScrollButtonVisibility = () => {
     if (rootRef.current) {
-      setIsLeftButtonVisible(rootRef.current ? rootRef.current.scrollLeft > 0 : false);
+      setIsLeftButtonVisible(rootRef.current.scrollLeft > scrollThreshold);
       setIsRightButtonVisible(
-        rootRef.current
-          ? rootRef.current.clientWidth + Math.ceil(rootRef.current.scrollLeft) < rootRef.current.scrollWidth
-          : false,
+        rootRef.current.scrollWidth - rootRef.current.clientWidth - rootRef.current.scrollLeft > scrollThreshold,
       );
     }
   };


### PR DESCRIPTION
## Included

- `fix(react-kit)`: 스크롤이 필요 없는데도 Tab 좌우 스크롤 버튼이 노출되던 문제 수정 (Safari에서 `clientWidth`는 내림, `scrollWidth`는 올림으로 정수화되어 생기는 1px 오차를 임계값으로 흡수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)