### PR TITLE
Deploy ✂️

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -12,9 +12,22 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/index.js",
       "types": "./dist/index.d.ts",
-      "import": "./esm/index.js"
+      "import": "./esm/index.js",
+      "require": "./dist/index.js"
+    },
+    "./enigma": {
+      "types": "./dist/enigma/index.d.ts",
+      "import": "./esm/enigma/index.js",
+      "require": "./dist/enigma/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "enigma": [
+        "./dist/enigma/index.d.ts"
+      ]
     }
   },
   "repository": {

--- a/packages/react-kit/rollup.config.js
+++ b/packages/react-kit/rollup.config.js
@@ -5,7 +5,8 @@ const nodeResolve = require('@rollup/plugin-node-resolve');
 const postcss = require('rollup-plugin-postcss');
 
 module.exports = {
-  input: 'src/index.ts',
+  // enigma는 `@teamturing/icons` 전체를 참조하므로 별도 진입점으로 분리한다
+  input: { 'index': 'src/index.ts', 'enigma/index': 'src/enigma/index.ts' },
   output: [
     {
       dir: 'dist',

--- a/packages/react-kit/src/core/Grid/index.tsx
+++ b/packages/react-kit/src/core/Grid/index.tsx
@@ -126,7 +126,10 @@ const mapValueToResponsiveValueProps = <T,>(
 };
 
 const Unit = ({ size, as, children, ...props }: PropsWithChildren<GridUnitProps>) => {
-  const getFlexGrowBySize = (size: UnitSizeType) => (size === 'max' ? 1 : size === 'min' ? 0 : 1);
+  /**
+   * `flex-grow`는 아래 `flex` 단축 속성이 결정합니다.
+   * 별도로 지정하면 단축 속성에 덮어써져 효과가 없고, DOM으로만 전달됩니다.
+   */
   const getFlexBySize = (size: UnitSizeType) => (size === 'max' ? 1 : size === 'min' ? 'none' : 'none');
   const getFlexBasisBySize = (size: UnitSizeType) => {
     const percentage = Math.round((size as number) * 100 * 10000) / 10000;
@@ -141,7 +144,6 @@ const Unit = ({ size, as, children, ...props }: PropsWithChildren<GridUnitProps>
     <View
       {...mapValueToResponsiveValueProps(size, (value) => ({
         display: value === 0 ? 'none' : 'initial',
-        flowGrow: getFlexGrowBySize(value),
         flex: getFlexBySize(value),
         flexBasis: getFlexBasisBySize(value),
         width: getWidthBySize(value),

--- a/packages/react-kit/src/core/Pill/index.tsx
+++ b/packages/react-kit/src/core/Pill/index.tsx
@@ -194,7 +194,7 @@ const BasePill = styled(UnstyledButton)<
           'fontWeight': theme.fontWeights.medium,
           'lineHeight': theme.lineHeights[2],
           'columnGap': 0.25,
-          '& svg': { minWidth: 12, height: 12 },
+          '& svg': { width: 12, minWidth: 12, height: 12 },
           '& > div': { p: 1 },
         },
         m: {
@@ -206,7 +206,7 @@ const BasePill = styled(UnstyledButton)<
           'fontWeight': theme.fontWeights.medium,
           'lineHeight': theme.lineHeights[2],
           'columnGap': 1,
-          '& svg': { minWidth: 12, height: 12 },
+          '& svg': { width: 12, minWidth: 12, height: 12 },
           '& > div': { p: 1 },
         },
       },

--- a/packages/react-kit/src/core/StyledIcon/index.tsx
+++ b/packages/react-kit/src/core/StyledIcon/index.tsx
@@ -7,12 +7,18 @@ type Props = {
    * @teamturing/icons와 함께 사용
    */
   icon: ComponentType<SVGProps<SVGSVGElement>>;
+  /**
+   * 선(stroke)으로 그려진 아이콘의 선 굵기를 정의합니다.
+   * `lucide`, `tabler`처럼 `stroke-width`가 고정된 아이콘은 `size`를 줄이면 선도 함께 얇아지므로,
+   * 이 값으로 보정합니다. 면(fill)으로 그려진 아이콘에는 영향이 없습니다.
+   */
+  strokeWidth?: number | string;
 } & Pick<ViewProps, 'size' | 'color' | 'sx'> &
   Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'aria-label' | 'aria-hidden'>;
 
 const StyledIcon = forwardRef<HTMLDivElement, Props>(
   (
-    { 'icon': Icon, sx, className, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden, ...props },
+    { 'icon': Icon, strokeWidth, sx, className, 'aria-label': ariaLabel, 'aria-hidden': ariaHidden, ...props },
     ref: Ref<HTMLDivElement>,
   ) => {
     /**
@@ -30,7 +36,19 @@ const StyledIcon = forwardRef<HTMLDivElement, Props>(
         {...a11yProps}
         className={`trk-styled_icon__wrapper ${className}`}
         color={props.color as any}
-        sx={{ '& svg': { display: 'inline-flex', width: '100%', height: '100%' }, ...sx }}
+        sx={{
+          /**
+           * `stroke-width`는 CSS가 presentation attribute를 이기므로,
+           * 아이콘 컴포넌트가 props를 전달하지 않아도 적용됩니다.
+           */
+          '& svg': {
+            display: 'inline-flex',
+            width: '100%',
+            height: '100%',
+            ...(strokeWidth !== undefined ? { strokeWidth } : {}),
+          },
+          ...sx,
+        }}
       >
         <Icon />
       </View>

--- a/packages/react-kit/src/enigma/EnigmaUI/index.tsx
+++ b/packages/react-kit/src/enigma/EnigmaUI/index.tsx
@@ -74,3 +74,4 @@ export const getViewComponent: (viewContainer: ViewContainerType) => ComponentTy
 };
 
 export default Object.assign(EnigmaUI, { TextView, ImageView, IconView, ChipGroupView, GridView });
+export type { Props as EnigmaUIProps };

--- a/packages/react-kit/src/enigma/index.ts
+++ b/packages/react-kit/src/enigma/index.ts
@@ -1,0 +1,28 @@
+/**
+ * enigma 진입점 (`@teamturing/react-kit/enigma`)
+ *
+ * enigma는 아이콘 이름 문자열로 아이콘을 조회하기 때문에 `@teamturing/icons` 전체를 참조합니다.
+ * 이를 메인 진입점에서 분리해, enigma를 쓰지 않는 애플리케이션이 아이콘 전량을
+ * 번들에 포함하지 않도록 합니다.
+ */
+export { default as EnigmaUI } from './EnigmaUI';
+export type { EnigmaUIProps } from './EnigmaUI';
+
+export type {
+  TextViewType,
+  ImageViewType,
+  IconViewType,
+  ChipGroupViewType,
+  GridViewType,
+  HorizontalDividerViewType,
+  ViewType,
+  ViewComponentType,
+  ViewContainerType,
+  ViewContainerDetailType,
+  SingleColumnLayoutType,
+  LayoutType,
+  LayoutComponentType,
+  LayoutContainerType,
+  ResponsiveLayoutContainerType,
+  EnigmaSectionType,
+} from './types';

--- a/packages/react-kit/src/index.ts
+++ b/packages/react-kit/src/index.ts
@@ -223,8 +223,10 @@ export type { UnstyledButtonProps } from './core/_UnstyledButton';
 
 /**
  * enigma component
+ *
+ * enigma는 `@teamturing/icons` 전체를 참조하므로 `@teamturing/react-kit/enigma`로 분리되어 있습니다.
+ * 메인 진입점에서 re-export하면 enigma를 쓰지 않는 애플리케이션도 아이콘 전량을 번들에 포함하게 됩니다.
  */
-export { default as EnigmaUI } from './enigma/EnigmaUI';
 
 /**
  * hooks


### PR DESCRIPTION
## Included

- `feat(react-kit)!`: `EnigmaUI`를 `@teamturing/react-kit/enigma` 서브패스로 분리 (enigma가 아이콘을 이름 문자열로 조회하려고 `@teamturing/icons`를 namespace로 import해, enigma를 쓰지 않는 앱도 아이콘 291개를 전부 번들에 포함하던 문제 — 메인 진입점만 사용 시 실측 291개 → 9개, 954kB → 638kB)
- `feat(react-kit)`: `StyledIcon`에 `strokeWidth` prop 추가 (lucide·tabler처럼 선으로 그려진 아이콘은 `stroke-width`가 고정이라 `size`를 줄이면 선도 함께 얇아지는 것을 보정. CSS가 presentation attribute를 이기므로 아이콘 컴포넌트가 props를 전달하지 않아도 적용됨)
- `fix(react-kit)`: Pill 아이콘에 `width`와 `min-width`를 함께 지정 (`min-width`만 있어 svg 고유 너비가 12px보다 크면 `height`만 고정되어 비율이 깨지던 문제. flex 컨테이너에서의 축소 방지는 유지)
- `fix(react-kit)`: `Grid.Unit`의 `flowGrow` 오타 선언 제거 (styled-system이 인식하지 못해 CSS로 반영되지 않았고, `flex-grow`는 뒤에 오는 `flex` 단축 속성이 결정하므로 불필요. 세 가지 size 모두 제거 전후 최종 flex 값이 동일함을 확인)

## ⚠️ Breaking change

`EnigmaUI`를 메인 진입점에서 더 이상 export하지 않습니다. enigma 관련 타입도 같은 경로에서 함께 export됩니다.

```diff
- import { EnigmaUI } from '@teamturing/react-kit';
+ import { EnigmaUI } from '@teamturing/react-kit/enigma';
```

## 검증

외부 아이콘 세트 도입 사전 검토용 플레이그라운드(react-kit의 아이콘 슬롯 13곳에 자사·lucide·tabler·Material Symbols를 나란히 렌더)에 로컬 빌드를 설치해 확인했습니다.

- 번들 실측: `@teamturing/icons` 단독 1kB / 메인 진입점 638kB(아이콘 9개) / `+ /enigma` 954kB(아이콘 291개)
- `strokeWidth` 1 / 1.5 / 2 / 2.5가 CSS로 출력되고 DOM 속성으로 새지 않음을 확인
- Pill svg에 `width`·`min-width`가 모두 적용됨을 확인
- jsdom 렌더 316개 svg 정상, React 경고 15건 → 14건

`check:lint`, `check:type`, 빌드(두 진입점 모두 `dist`/`esm`/`.d.ts` 생성) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
