### PR TITLE
Deploy ⚖️

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -64,6 +64,20 @@ lucide의 `stroke-width="2"`는 **24px로 그렸을 때** 기준이다. 16px나 
 
 react-kit을 쓴다면 `StyledIcon`의 `strokeWidth` prop이 같은 일을 한다.
 
+## 라이선스
+
+이 패키지의 코드는 MIT다. `@teamturing/icons/lucide`의 아이콘은 [lucide](https://lucide.dev)에서
+파생된 것으로 **ISC**를 따르고, 그중 `search`·`check`·`calendar`처럼 Feather 프로젝트에서
+파생된 약 110개는 별도의 **MIT**(Copyright (c) 2013-present Cole Bemis)를 따른다.
+
+두 라이선스 모두 저작권 표시와 허가 문구를 사본에 유지할 것을 조건으로 한다. 그래서
+`THIRD-PARTY-NOTICES.md`에 전문을 싣고, 빌드 산출물의 lucide 모듈마다 `@license` 배너를 붙인다.
+배너를 엔트리에만 붙이면 트리셰이킹이 배럴을 걷어낼 때 표시도 함께 사라지므로,
+상류인 `lucide-react`와 마찬가지로 아이콘 파일마다 붙인다.
+
+자사 아이콘 쪽에는 붙지 않는다. lucide를 쓰지 않는 번들에 lucide 표시가 들어가면
+그것대로 잘못된 출처 표시이기 때문이다.
+
 ## 아이콘 추가·갱신
 
 ```bash

--- a/packages/icons/THIRD-PARTY-NOTICES.md
+++ b/packages/icons/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,60 @@
+# Third-party notices
+
+`@teamturing/icons` 자체는 MIT입니다. 아래는 이 패키지에 포함된 외부 저작물의 라이선스입니다.
+
+## lucide
+
+`@teamturing/icons/lucide`로 제공되는 아이콘 1769개는 [lucide](https://lucide.dev)에서
+파생됐습니다 (`lucide-static` v1.32.0). 원본 svg를 SVGR로 React 컴포넌트로 변환한 것 외에
+형태를 바꾸지 않았습니다.
+
+아래는 lucide가 배포하는 LICENSE 전문입니다. 두 번째 절은 lucide 중 Feather 프로젝트에서
+파생된 아이콘에 적용됩니다.
+
+```
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+> 이 파일은 `scripts/collect-lucide.mjs`가 생성합니다. 직접 고치지 마세요.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,13 +4,14 @@
   "description": "Icon components for React based project",
   "author": "Sungchang Park <psch300@gmail.com> (https://github.com/psch300)",
   "homepage": "https://github.com/weareteamturing/bombe#readme",
-  "license": "MIT",
+  "license": "MIT AND ISC",
   "main": "./dist/index.js",
   "sideEffects": false,
   "files": [
     "dist",
     "esm",
-    "svg"
+    "svg",
+    "THIRD-PARTY-NOTICES.md"
   ],
   "exports": {
     ".": {

--- a/packages/icons/rollup.config.js
+++ b/packages/icons/rollup.config.js
@@ -4,6 +4,8 @@ const commonjs = require('@rollup/plugin-commonjs');
 const nodeResolve = require('@rollup/plugin-node-resolve');
 const svgr = require('@svgr/rollup');
 
+const { version: LUCIDE_VERSION } = require('lucide-static/package.json');
+
 const plugins = () => [
   nodeResolve({ extensions: ['.ts', '.tsx', '.js', '.jsx'] }),
   commonjs(),
@@ -27,22 +29,54 @@ const plugins = () => [
  * (`src/lucide/Search.tsx` → `esm/lucide/Search.js`). 지정하지 않으면 rollup이 각 빌드의
  * 공통 조상을 따로 계산해 lucide 쪽이 `esm/` 바로 아래로 평탄화된다.
  */
-const entry = (input, cjsDir) => ({
+const entry = (input, cjsDir, banner) => ({
   input,
   output: [
     {
       dir: cjsDir,
       format: 'cjs',
+      banner,
     },
     {
       dir: 'esm',
       format: 'esm',
       preserveModules: true,
       preserveModulesRoot: 'src',
+      banner,
     },
   ],
   external: ['react'],
   plugins: plugins(),
 });
 
-module.exports = [entry('src/index.ts', 'dist'), entry('src/lucide/index.ts', 'dist/lucide')];
+/**
+ * lucide 산출물에 붙는 저작권 표시.
+ *
+ * ISC는 저작권 표시와 허가 문구가 모든 사본에 나타날 것을 조건으로 한다. 패키지에는
+ * `THIRD-PARTY-NOTICES.md`로 전문을 싣지만, 소비처가 번들링하면 그 파일은 따라가지 않는다.
+ * 그래서 코드 자체에도 출처를 남긴다.
+ *
+ * 엔트리뿐 아니라 모든 모듈에 붙인다. 트리셰이킹이 배럴(`index.js`)을 걷어내면 거기 붙은
+ * 표시도 함께 사라지므로, 엔트리에만 붙이면 정작 아이콘을 골라 쓰는 흔한 경우에 표시가
+ * 남지 않는다. 상류인 `lucide-react`도 아이콘 파일마다 같은 배너를 붙인다.
+ *
+ * `@license`가 들어간 주석은 terser·esbuild가 기본 설정에서 보존하므로 프로덕션 번들까지
+ * 살아남는다.
+ */
+const LUCIDE_BANNER = `/**
+ * @license lucide v${LUCIDE_VERSION} - ISC
+ *
+ * Copyright (c) Lucide Icons and Contributors
+ * Some icons are derived from Feather (MIT), copyright (c) 2013-present Cole Bemis.
+ * See THIRD-PARTY-NOTICES.md in this package for the full license text.
+ */`;
+
+module.exports = [
+  entry('src/index.ts', 'dist'),
+  /**
+   * `_virtual/`은 두 빌드가 공유하는 babel 헬퍼라 lucide 것이 아니다. 여기에 배너를 붙이면
+   * 자사 아이콘만 쓰는 번들에도 lucide 표시가 딸려 들어간다(두 빌드가 같은 파일을 쓰고
+   * lucide 쪽이 나중에 덮어쓰기 때문). 잘못된 출처 표시이므로 제외한다.
+   */
+  entry('src/lucide/index.ts', 'dist/lucide', (chunk) => (chunk.fileName.includes('_virtual') ? '' : LUCIDE_BANNER)),
+];

--- a/packages/icons/scripts/collect-lucide.mjs
+++ b/packages/icons/scripts/collect-lucide.mjs
@@ -45,5 +45,47 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
+/**
+ * lucide의 라이선스 전문을 패키지에 함께 싣는다.
+ *
+ * ISC는 "저작권 표시와 허가 문구가 모든 사본에 나타날 것"을 조건으로 한다. 그런데 SVGO가
+ * 변환 과정에서 원본 svg의 `<!-- @license ... -->` 주석을 지우기 때문에, 생성된 컴포넌트에는
+ * 아무 표시도 남지 않는다. 그래서 여기서 별도 파일로 옮겨 둔다.
+ *
+ * lucide의 LICENSE에는 ISC 외에 두 번째 절이 있다. `search`, `check`처럼 Feather 프로젝트에서
+ * 파생된 약 110개는 Cole Bemis의 MIT를 따른다. 전문을 그대로 옮기므로 그쪽도 함께 유지된다.
+ *
+ * 손으로 옮겨 적지 않고 설치된 패키지에서 읽는 이유는, lucide 버전을 올릴 때 저작권 연도나
+ * Feather 목록이 바뀌어도 `yarn svgr:lucide` 한 번으로 따라오게 하기 위해서다.
+ */
+const NOTICE_FILE = path.join(PKG_DIR, 'THIRD-PARTY-NOTICES.md');
+const licenseText = fs.readFileSync(path.join(LUCIDE_DIR, 'LICENSE'), 'utf8').trimEnd();
+
+fs.writeFileSync(
+  NOTICE_FILE,
+  [
+    '# Third-party notices',
+    '',
+    '`@teamturing/icons` 자체는 MIT입니다. 아래는 이 패키지에 포함된 외부 저작물의 라이선스입니다.',
+    '',
+    '## lucide',
+    '',
+    `\`@teamturing/icons/lucide\`로 제공되는 아이콘 ${canonical.length}개는 [lucide](https://lucide.dev)에서`,
+    `파생됐습니다 (\`lucide-static\` v${version}). 원본 svg를 SVGR로 React 컴포넌트로 변환한 것 외에`,
+    '형태를 바꾸지 않았습니다.',
+    '',
+    '아래는 lucide가 배포하는 LICENSE 전문입니다. 두 번째 절은 lucide 중 Feather 프로젝트에서',
+    '파생된 아이콘에 적용됩니다.',
+    '',
+    '```',
+    licenseText,
+    '```',
+    '',
+    '> 이 파일은 `scripts/collect-lucide.mjs`가 생성합니다. 직접 고치지 마세요.',
+    '',
+  ].join('\n'),
+);
+
 const published = fs.readdirSync(path.join(LUCIDE_DIR, 'icons')).filter((f) => f.endsWith('.svg')).length;
 console.log(`lucide-static v${version}: 배포 ${published}개 중 정식 이름 ${canonical.length}개를 .lucide-svg/에 모았습니다.`);
+console.log(`라이선스 전문을 ${path.basename(NOTICE_FILE)}에 기록했습니다.`);

--- a/packages/icons/scripts/verify-lucide.mjs
+++ b/packages/icons/scripts/verify-lucide.mjs
@@ -74,6 +74,17 @@ for (const f of files) {
   if (!source.includes('viewBox=')) errors.push(`viewBox가 없습니다: ${f}`);
 }
 
+/**
+ * 라이선스 전문이 패키지에 실리는가.
+ * ISC의 조건이라 빠지면 게시 자체가 문제가 된다.
+ */
+const NOTICE_FILE = path.join(PKG_DIR, 'THIRD-PARTY-NOTICES.md');
+if (!fs.existsSync(NOTICE_FILE)) {
+  errors.push('THIRD-PARTY-NOTICES.md가 없습니다. collect-lucide.mjs를 먼저 실행하세요.');
+} else if (!fs.readFileSync(NOTICE_FILE, 'utf8').includes('ISC License')) {
+  errors.push('THIRD-PARTY-NOTICES.md에 lucide 라이선스 전문이 없습니다.');
+}
+
 if (errors.length > 0) {
   console.error(`lucide 검증 실패 (${errors.length}건)`);
   for (const e of errors.slice(0, 20)) console.error(`  - ${e}`);


### PR DESCRIPTION
## Included

- `fix(icons)`: lucide 라이선스 표시를 패키지에 싣는다

## 무엇이 문제였나

`2.0.0`은 **lucide의 저작권 표시 없이 게시됐습니다.**

lucide는 ISC이고, 두 라이선스 모두 저작권 표시와 허가 문구를 사본에 유지할 것을 조건으로 합니다. 그런데 어디에도 남아 있지 않았습니다.

| 항목 | 2.0.0 상태 |
| --- | --- |
| 생성된 `src/lucide/*.tsx` | lucide 언급 0건 |
| 빌드 산출물 `dist/lucide/index.js` | 0건 |
| 패키지 LICENSE | 우리 MIT 하나뿐 (`Copyright (c) 2023 weareteamturing`) |
| `license` 필드 | `MIT` |

원인은 두 가지입니다. SVGO가 변환 과정에서 원본 svg의 `<!-- @license lucide-static v1.32.0 - ISC -->` 주석을 지웠고, `packages/icons/`에 LICENSE가 없어 lerna가 리포 루트의 MIT를 복사해 넣었습니다. 결과적으로 **lucide 파생 아이콘 1769개를 우리 저작권 표시만 붙여 배포**하는 형태였습니다.

lucide LICENSE에는 ISC 외에 두 번째 절이 있습니다. `search`, `check`, `calendar`, `trash-2` 등 **약 110개는 Feather 프로젝트에서 파생되어 별도의 MIT**(Copyright (c) 2013-present Cole Bemis)를 따릅니다. 이것도 함께 유지해야 합니다.

## 고친 방식

**1. `THIRD-PARTY-NOTICES.md`에 전문을 싣고 `files`에 추가**

손으로 옮겨 적지 않고 `collect-lucide.mjs`가 설치된 `lucide-static`의 LICENSE를 읽어 생성합니다. lucide 버전을 올릴 때 저작권 연도나 Feather 아이콘 목록이 바뀌어도 `yarn svgr:lucide` 한 번으로 따라옵니다.

**2. 빌드 산출물의 lucide 모듈마다 `@license` 배너**

패키지에 실은 파일은 소비처가 번들링하면 따라가지 않습니다. 처음엔 엔트리 청크에만 붙였는데, 실측해보니 **트리셰이킹이 배럴(`index.js`)을 걷어낼 때 표시도 함께 사라졌습니다** — 아이콘을 골라 쓰는 가장 흔한 경우에 정작 남지 않는 것이죠. 상류인 `lucide-react`도 아이콘 파일마다 같은 배너를 붙이고 있어 그 방식에 맞췄습니다.

**3. `license` 필드를 `MIT AND ISC`로**

실제 구성을 드러내는 SPDX 표현입니다. 사용처의 라이선스 스캐너가 ISC를 인식하게 됩니다.

## 잡은 부작용 — 자사 번들의 잘못된 출처 표시

배너를 모든 청크에 붙였더니 **lucide를 전혀 쓰지 않는 번들에도 lucide 표시가 들어갔습니다.** 두 빌드가 공유하는 babel 헬퍼(`esm/_virtual/_rollupPluginBabelHelpers.js`)를 lucide 빌드가 나중에 덮어쓰기 때문입니다. 헬퍼는 lucide 저작물이 아니므로 그것대로 잘못된 표시라 제외했습니다.

## 검증

소비처 앱에서 rollup 빌드 후 실측했습니다.

| 번들 | 전 | 후 | lucide 표시 |
| --- | --- | --- | --- |
| 자사에서 1개 | 1,144 B | **1,144 B** | 없음 (의도대로) |
| `/lucide`에서 1개 | 937 B | 1,187 B | 있음 |
| 양쪽에서 1개씩 | 1,900 B | 2,150 B | 있음 |
| 양쪽 + `as` 별칭 | 1,640 B | 1,890 B | 있음 |

- 패키지: unpacked 3.97 → **4.42MB**, packed 0.70 → **0.71MB**
- 자사 CJS 엔트리 **338,589 B — 변함 없음**
- `esm/`에서 배너가 붙은 파일은 `lucide/` 아래 1770개뿐, `_virtual/`과 자사 아이콘에는 0개
- `verify-lucide.mjs`에 전문 파일 존재·내용 확인을 추가해 앞으로 빠지면 생성 단계에서 걸립니다

`check:lint`, `check:type`, `build`, `test` 모두 통과했습니다.

## 릴리스 영향

| 패키지 | 현재 | 예상 |
| --- | --- | --- |
| `@teamturing/icons` | 2.0.0 | **2.0.1** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
